### PR TITLE
Use the linux lograte naming scheme

### DIFF
--- a/open-vm-tools/scripts/linux/network
+++ b/open-vm-tools/scripts/linux/network
@@ -37,9 +37,9 @@ rotate_logfile() {
     max=`expr $max - 1`
     for s in `seq $max -1 1`; do
         d=`expr $s + 1`
-        mv -f $logbase.$s.log $logbase.$d.log
+        mv -f $logbase.log.$s $logbase.log.$d
     done
-    mv -f $logbase.log $logbase.1.log
+    mv -f $logbase.log $logbase.log.1
 }
 
 rotate_logfile


### PR DESCRIPTION
Instead of rotating the logs to:

    /var/log/vmware-network.1.log
    /var/log/vmware-network.2.log
    /var/log/vmware-network.3.log
    /var/log/vmware-network.log

rotate them to

    /var/log/vmware-network.log.1
    /var/log/vmware-network.log.2
    /var/log/vmware-network.log.3
    /var/log/vmware-network.log

This is the default logrotate naming scheme.